### PR TITLE
- Removed grok for OwnOrganizationServicesVocabulary + utils.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,17 @@ Changelog
 1.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Removed grok for OwnOrganizationServicesVocabulary.
+  [gbastien]
+- Added utils.get_organization to get an organization corresponding
+  to a given plone_group_id.
+  [gbastien]
+- Added utils.get_organizations to get every plonegroup organizations.  It is
+  possible to get every selectable or selected organizations, as objects or not
+  and for which a particular linked Plone group (suffix) is not empty.
+  [gbastien]
+- Added utils.get_all_suffixes that returns every defined functions ids.
+  [gbastien]
 
 1.9 (2018-09-04)
 ----------------

--- a/src/collective/contact/plonegroup/browser/configure.zcml
+++ b/src/collective/contact/plonegroup/browser/configure.zcml
@@ -18,6 +18,10 @@
         class=".settings.SettingsView" />
 
     <utility
+        name="collective.contact.plonegroup.organization_services"
+        factory=".settings.OwnOrganizationServicesVocabulary" />
+
+    <utility
         name="collective.contact.plonegroup.selected_organization_services"
         factory=".settings.SelectedOrganizationsElephantVocabulary" />
 

--- a/src/collective/contact/plonegroup/subscribers.py
+++ b/src/collective/contact/plonegroup/subscribers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_get
 from collective.contact.plonegroup import _
-from config import FUNCTIONS_REGISTRY
+from collective.contact.plonegroup.utils import get_all_suffixes
 from config import ORGANIZATIONS_REGISTRY
 from config import PLONEGROUP_ORG
 from interfaces import INotPloneGroupContact
@@ -194,8 +194,7 @@ def group_deleted(event):
         return
     group_suffix = '_'.join(parts[1:])
     registry = getUtility(IRegistry)
-    if parts[0] in registry[ORGANIZATIONS_REGISTRY] and \
-            group_suffix in [dic['fct_id'] for dic in registry[FUNCTIONS_REGISTRY]]:
+    if parts[0] in registry[ORGANIZATIONS_REGISTRY] and group_suffix in get_all_suffixes():
         orga = api.content.find(UID=parts[0])[0].getObject()
         api.portal.show_message(message=_("You cannot delete the group '${group}', linked to used organization "
                                           "'${orga}'.", mapping={'group': group, 'orga': safe_unicode(orga.Title())}),


### PR DESCRIPTION
- Added utils.get_organization to get an organization corresponding to a given plone_group_id.
- Added utils.get_organizations to get every plonegroup organizations.  It is possible to get every selectable or selected organizations, as objects or not and for which a particular linked Plone group (suffix) is not empty.
- Added utils.get_all_suffixes that returns every defined functions ids.