### PR TITLE
Fixed `addOrModifyOrganizationGroups` called when an organization is modified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ Changelog
 1.35 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Fixed `addOrModifyOrganizationGroups` called when an organization is modified,
+  that was creating Plone groups for every suffixes without considering
+  `enabled` or `fct_orgs`. Added upgrade step to `v8` that will delete Plone
+  groups that were wrongly created.
+  [gbastien]
 
 1.34 (2021-04-20)
 -----------------

--- a/src/collective/contact/plonegroup/browser/settings.py
+++ b/src/collective/contact/plonegroup/browser/settings.py
@@ -454,8 +454,12 @@ def addOrModifyOrganizationGroups(organization, uid):
         Modify groups linked to an organization
     """
     changes = False
-    for dic in get_registry_functions():
-        if addOrModifyGroup(organization, dic['fct_id'], dic['fct_title']):
+    # filter only relevant suffixes
+    suffixes = get_all_suffixes(uid)
+    functions = [f for f in get_registry_functions()
+                 if f['fct_id'] in suffixes]
+    for fct in functions:
+        if addOrModifyGroup(organization, fct['fct_id'], fct['fct_title']):
             changes = True
     return changes
 

--- a/src/collective/contact/plonegroup/profiles/default/metadata.xml
+++ b/src/collective/contact/plonegroup/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>7</version>
+  <version>8</version>
   <dependencies>
     <dependency>profile-collective.contact.core:default</dependency>
   </dependencies>

--- a/src/collective/contact/plonegroup/upgrades/configure.zcml
+++ b/src/collective/contact/plonegroup/upgrades/configure.zcml
@@ -53,4 +53,12 @@
       handler=".upgrades.v7"
       profile="collective.contact.plonegroup:default" />
 
+  <genericsetup:upgradeStep
+      title="Migration profile for collective.contact.plonegroup to 8"
+      description="Upgrade from 7 to 8"
+      source="7"
+      destination="8"
+      handler=".upgrades.v8"
+      profile="collective.contact.plonegroup:default" />
+
 </configure>


### PR DESCRIPTION
That was creating Plone groups for every suffixes without considering `enabled` or `fct_orgs`. Added upgrade step to `v8` that will delete Plone groups that were wrongly created.

See #SUP-18401