### PR TITLE
Added parameter `verify_group_exist=True` to `utils.get_plone_groups`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           bin/test -t !robot
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Changelog
 1.52 (unreleased)
 -----------------
 
-- Nothing changed yet.
-
+- Added parameter `verify_group_exist=True` to `utils.get_plone_groups`.
+  When set to `False`, it will not get the real Plone group object to check
+  if it exist when using `ids_only=True`. In this case it is much faster.
+  [gbastien]
 
 1.51 (2024-10-02)
 -----------------

--- a/src/collective/contact/plonegroup/tests/test_utils.py
+++ b/src/collective/contact/plonegroup/tests/test_utils.py
@@ -179,10 +179,17 @@ class TestUtils(IntegrationTestCase):
     def test_get_plone_groups(self):
         plone_groups = [get_plone_group(self.uid, 'observer'), get_plone_group(self.uid, 'director')]
         self.assertEqual(get_plone_groups(self.uid, ids_only=False), plone_groups)
+        self.assertEqual(get_plone_groups(self.uid, ids_only=False, verify_group_exist=False), plone_groups)
         self.assertEqual(get_plone_groups(self.uid, ids_only=True), [g.id for g in plone_groups])
+        self.assertEqual(get_plone_groups(self.uid, ids_only=True, verify_group_exist=False),
+                         [g.id for g in plone_groups])
         self.assertEqual(get_plone_groups(self.uid, suffixes=['observer']), [plone_groups[0]])
         self.assertEqual(get_plone_groups(self.uid, suffixes=['unknown_suffix']), [])
         self.assertEqual(get_plone_groups(self.uid, ids_only=True, suffixes=['unknown_suffix']), [])
+        # when using verify_group_exist=False we must make sure it exists or it is returned
+        self.assertEqual(get_plone_groups("wrong_uid", ids_only=True, verify_group_exist=False),
+                         ['wrong_uid_observer', 'wrong_uid_director'])
+        self.assertEqual(get_plone_groups("wrong_uid", ids_only=False, verify_group_exist=False), [])
 
     def test_get_organization(self):
         suffixed_org = get_plone_group_id(self.uid, 'suffix')

--- a/src/collective/contact/plonegroup/utils.py
+++ b/src/collective/contact/plonegroup/utils.py
@@ -113,20 +113,24 @@ def get_plone_group(prefix, suffix):
     return api.group.get(get_plone_group_id(prefix, suffix))
 
 
-def get_plone_groups(org_uid, ids_only=False, suffixes=[]):
+def get_plone_groups(org_uid, ids_only=False, verify_group_exist=True, suffixes=[]):
     """
         Return Plone groups linked to given org_uid.
         If ids_only is True, only returns Plone groups ids,
         either returns Plone group objects.
         Only returns Plone groups using suffixes if provided.
+        If verify_group_exist=True, real group object is retrieved
+        to check if it exists, even when ids_only=False.
+        For performance, use ids_only=False and verify_group_exist=False.
     """
     suffixes = suffixes or get_all_suffixes(org_uid)
     plone_groups = [get_plone_group_id(org_uid, suffix) for suffix in suffixes]
-    plone_groups = [api.group.get(plone_group) for plone_group in plone_groups]
-    # remove None values
-    plone_groups = [v for v in plone_groups if v]
-    if ids_only:
-        plone_groups = [plone_group.getId() for plone_group in plone_groups]
+    if not ids_only or verify_group_exist:
+        plone_groups = [api.group.get(plone_group) for plone_group in plone_groups]
+        # remove None values
+        plone_groups = [v for v in plone_groups if v]
+        if ids_only:
+            plone_groups = [plone_group.getId() for plone_group in plone_groups]
     return plone_groups
 
 


### PR DESCRIPTION
When set to `False`, it will not get the real Plone group object to check if it exist when using `ids_only=True`. In this case it is much faster.

See #MOD-1019