### PR TITLE
DMS-434: Fixed ConnectionStateError crash when rendering datagrid fields in settings through robotframework tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.57 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fixed ``ConnectionStateError`` crash when rendering datagrid fields
+  in settings through robotframework tests.
+  [chris-adam]
 
 
 1.56 (2026-03-03)

--- a/src/collective/contact/plonegroup/browser/settings.py
+++ b/src/collective/contact/plonegroup/browser/settings.py
@@ -32,6 +32,7 @@ from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form import form
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from zExceptions import Redirect
+from ZODB.POSException import ConnectionStateError
 from zope import schema
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -441,6 +442,15 @@ class SettingsEditForm(RegistryEditForm):
     form.extends(RegistryEditForm)
     schema = IContactPlonegroupConfig
     label = PloneMessageFactory(u"Contact Plone Group settings")
+
+    def update(self):
+        field = self.schema.get('functions')
+        if field is not None and getattr(field, 'value_type', None) is not None:
+            try:
+                field.value_type.schema
+            except ConnectionStateError:
+                field.value_type = DictRow(title=field.title, schema=IFunctionSchema)
+        super(SettingsEditForm, self).update()
 
 
 SettingsView = layout.wrap_form(SettingsEditForm, ControlPanelFormWrapper)


### PR DESCRIPTION
## Summary

The `@@contact-plonegroup-settings` control panel crashes with `ConnectionStateError` when rendered under a running zserver (functional / robot-framework tests). This is the same class of bug reported for iMio's `imio.dms.mail` settings panel (internal ticket DMS-434); this PR fixes the occurrence that lives in this package.

## Technical analysis

### Symptom

```
ConnectionStateError: Shouldn't load state for 0x... when the connection is closed
  ...
  Module z3c.form.field, line ..., in update
  Module plone.autoform.widgets, line ..., in __call__
  Module collective.z3cform.datagridfield.datagridfield, in DataGridFieldFactory
  Module z3c.form.widget, in FieldWidget
  Module collective.z3cform.datagridfield.datagridfield, in field   # the `field` setter
  Module ZODB.Connection, in setstate
```

### Root cause

The `functions` field of `IContactPlonegroupConfig` is a `schema.List` whose `value_type` is a
`collective.z3cform.datagridfield.registry.DictRow`. That `DictRow` subclasses `plone.registry`'s
`PersistentField`:

```python
class DictRow(PersistentField, BaseDictRow):
    pass
```

Because `IPersistentField(dictrow)` returns the object unchanged (it already provides the interface),
when the registry records are created from the interface at profile-import time, the **module-level
`value_type` singleton itself** is stored in the ZODB registry record and acquires a `_p_jar` bound to
the import-time connection.

When the control panel is rendered, `z3c.form` builds the `DataGridField` widget. Its `field` setter does:

```python
schema = self._field.value_type.schema
```

Reading `.schema` on the (now ghost) `DictRow` triggers a ZODB `setstate`. Under a **running zserver**
(functional / robot tests) the import-time connection is already closed by the time the form renders, so
the load fails with `ConnectionStateError`.

This does **not** happen:
- in a normally running instance — the connection stays open, so the state loads fine;
- in integration tests — a single, still-open connection is used throughout.

It only bites in the functional / robot scenario where the object was persisted on one connection and read
back on another that has since been closed.

### Fix

Heal the stale `value_type` at the point of failure, in `SettingsEditForm.update()`, before the widgets are
built:

```python
def update(self):
    field = self.schema.get('functions')
    if field is not None and getattr(field, 'value_type', None) is not None:
        try:
            field.value_type.schema
        except ConnectionStateError:
            field.value_type = DictRow(title=field.title, schema=IFunctionSchema)
    super(SettingsEditForm, self).update()
```

- In production / integration the `try` succeeds (open connection) → **no behaviour change whatsoever**.
- Under the functional / robot zserver the `except` fires and the `value_type` is rebuilt as a fresh
  in-memory `DictRow` with the same row schema (`IFunctionSchema`), so the widget can be built without
  touching the closed connection.

This mirrors the remedy already used in `imio.fpaudit` (catch `ConnectionStateError`, drop/rebuild the
persistent datagrid `value_type`), applied here at the render site where this control panel actually fails.

## Verification

- `bin/test -s collective.contact.plonegroup -m ...tests.test_settings` → **16 passed, 0 failures**.
- The iMio `imio.dms.mail` robot suite (`doc.robot` "Configuration") now renders `@@contact-plonegroup-settings`
  successfully, where it previously aborted on this error. (The equivalent fix for `imio.dms.mail`'s own
  settings panel is tracked separately.)

## Notes

- No unit test is added in this package: the failing code path requires a **closed** ZODB connection, which the
  integration test layer (single open connection) cannot reproduce. It is exercised by `imio.dms.mail`'s
  functional robot suite.
- Pure form-render fix — no GenericSetup profile, registry, or schema change, so no profile version bump / upgrade
  step is required.
